### PR TITLE
Allow GitHub to access the merges endpoint

### DIFF
--- a/api/github.go
+++ b/api/github.go
@@ -14,7 +14,7 @@ type GitHubGateway struct {
 }
 
 var pathRegexp = regexp.MustCompile("^/github/?")
-var allowedRegexp = regexp.MustCompile("^/github/(git|contents|pulls|branches)/?")
+var allowedRegexp = regexp.MustCompile("^/github/(git|contents|pulls|branches|merges)/?")
 
 func NewGitHubGateway() *GitHubGateway {
 	return &GitHubGateway{


### PR DESCRIPTION
This is still content related and should be allowed.

See https://github.com/netlify/git-gateway/issues/8#issuecomment-361157136 for a valid use case