### PR TITLE
Gitlab support fixes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -98,8 +98,8 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 	}
 
 	corsHandler := cors.New(cors.Options{
-		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", audHeaderName},
+		AllowedMethods:   []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Private-Token", "Content-Type", audHeaderName},
 		AllowCredentials: true,
 	})
 

--- a/api/gitlab.go
+++ b/api/gitlab.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"regexp"
+	"strings"
 )
 
 // GitLabGateway acts as a proxy to Gitlab
@@ -34,7 +35,11 @@ func gitlabDirector(r *http.Request) {
 	r.Host = target.Host
 	r.URL.Scheme = target.Scheme
 	r.URL.Host = target.Host
-	r.URL.Path = singleJoiningSlash(target.Path, gitlabPathRegexp.ReplaceAllString(r.URL.Path, "/"))
+	// We need to set URL.Opaque using the target and r.URL EscapedPath
+	// methods, because the Go stdlib URL parsing automatically converts
+	// %2F to / in URL paths, and GitLab requires %2F to be preserved
+	// as-is.
+	r.URL.Opaque = "//" + target.Host + singleJoiningSlash(target.EscapedPath(), gitlabPathRegexp.ReplaceAllString(r.URL.EscapedPath(), "/"))
 	if targetQuery == "" || r.URL.RawQuery == "" {
 		r.URL.RawQuery = targetQuery + r.URL.RawQuery
 	} else {
@@ -44,8 +49,9 @@ func gitlabDirector(r *http.Request) {
 		// explicitly disable User-Agent so it's not set to default value
 		r.Header.Set("User-Agent", "")
 	}
+	r.Header.Del("Authorization")
 	if r.Method != http.MethodOptions {
-		r.Header.Set("Authorization", "Bearer "+accessToken)
+		r.Header.Set("Private-Token", accessToken)
 	}
 
 	log := getLogEntry(r)
@@ -66,7 +72,10 @@ func (gl *GitLabGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	endpoint := config.GitLab.Endpoint
-	apiURL := singleJoiningSlash(endpoint, "/repos/"+config.GitLab.Repo)
+	// repos in the form of userName/repoName must be encoded as
+	// userName%2FrepoName
+	repo := url.PathEscape(config.GitLab.Repo)
+	apiURL := singleJoiningSlash(endpoint, "/projects/"+repo)
 	target, err := url.Parse(apiURL)
 	if err != nil {
 		handleError(internalServerError("Unable to process GitLab endpoint"), w, r)
@@ -110,13 +119,40 @@ func (gl *GitLabGateway) authenticate(w http.ResponseWriter, r *http.Request) er
 	return errors.New("Access to endpoint not allowed: your role doesn't allow access")
 }
 
+var gitlabLinkRegex = regexp.MustCompile("<(.*?)>")
+var gitlabLinkRelRegex = regexp.MustCompile("rel=\"(.*?)\"")
+
+func rewriteGitlabLinks(linkHeader, endpointAPIURL, proxyAPIURL string) string {
+	linkEntries := strings.Split(linkHeader, ",")
+	finalLinkEntries := []string{}
+	for _, linkEntry := range linkEntries {
+		linkAndRel := strings.Split(strings.TrimSpace(linkEntry), ";")
+		link := proxyAPIURL + strings.TrimPrefix(gitlabLinkRegex.FindStringSubmatch(linkAndRel[0])[1], endpointAPIURL)
+		rel := gitlabLinkRelRegex.FindStringSubmatch(linkAndRel[1])[1]
+		finalLinkEntries = append(finalLinkEntries, "<"+link+">; rel=\""+rel+"\"")
+	}
+	finalLinkHeader := strings.Join(finalLinkEntries, ",")
+	return finalLinkHeader
+}
+
 type GitLabTransport struct{}
 
 func (t *GitLabTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx := r.Context()
+	config := getConfig(ctx)
 	resp, err := http.DefaultTransport.RoundTrip(r)
 	if err == nil {
-		// remove CORS headers from GitHub and use our own
+		// remove CORS headers from GitLab and use our own
 		resp.Header.Del("Access-Control-Allow-Origin")
+		linkHeader := resp.Header.Get("Link")
+		if linkHeader != "" {
+			endpoint := config.GitLab.Endpoint
+			repo := url.PathEscape(config.GitLab.Repo)
+			apiURL := singleJoiningSlash(endpoint, "/projects/"+repo)
+			newLinkHeader := rewriteGitlabLinks(linkHeader, apiURL, "")
+			resp.Header.Set("Link", newLinkHeader)
+		}
 	}
+
 	return resp, err
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -9,6 +9,7 @@ import (
 )
 
 const DefaultGitHubEndpoint = "https://api.github.com"
+const DefaultGitLabEndpoint = "https://gitlab.com/api/v4"
 
 type GitHubConfig struct {
 	AccessToken string `envconfig:"ACCESS_TOKEN" json:"access_token,omitempty"`
@@ -105,5 +106,6 @@ func LoadConfig(filename string) (*Configuration, error) {
 func (config *Configuration) ApplyDefaults() {
 	if config.GitHub.Endpoint == "" {
 		config.GitHub.Endpoint = DefaultGitHubEndpoint
+		config.GitLab.Endpoint = DefaultGitLabEndpoint
 	}
 }


### PR DESCRIPTION
Fixes several bugs with GitLab support in git-gateway:

- Adds `HEAD` requests to the allowed CORS methods.
- Adds `"Private-Token"` to the allowed CORS headers.
- Constructs a URL by setting `r.URL.Opaque` instead of by setting `r.URL.Path` to prevent literal `%2F`s in URLs, which are required by the GitLab API, from being turned into literal `/` characters by the Go stdlib. (see [this github issue](https://github.com/golang/go/issues/6658) and [this commit](https://github.com/golang/go/commit/874a605af0764a8f340c3de65406963f514e21bc), noting that `git-gateway` is running on `go1.8` if I understand correctly from the `.travis.yml`).
- Removes the `Authorization` header from GitLab requests, which causes 401s when used with private access tokens ([example](https://gitlab.com/gitlab-com/support-forum/issues/2722)), and replaces it with the `Private-Token` header. (The current WIP Netlify UI has a box for a token to be pasted, so I assume this is supposed to be a private access token, not an OAuth token - which would use the `Authorization` header).
- Rewrites absolute links in the GitLab `Link` header to be relative, so they're requested from git-gateway instead of the proxied API.
- Adds a default value for the GitLab API endpoint.