### PR TITLE
Support both forms of GitLab access token

### DIFF
--- a/api/gitlab.go
+++ b/api/gitlab.go
@@ -49,9 +49,22 @@ func gitlabDirector(r *http.Request) {
 		// explicitly disable User-Agent so it's not set to default value
 		r.Header.Set("User-Agent", "")
 	}
-	r.Header.Del("Authorization")
-	if r.Method != http.MethodOptions {
-		r.Header.Set("Private-Token", accessToken)
+
+	config := getConfig(ctx)
+	tokenType := config.GitLab.AccessTokenType
+
+	if tokenType == "personal_access" {
+		// Private access token
+		r.Header.Del("Authorization")
+		if r.Method != http.MethodOptions {
+			r.Header.Set("Private-Token", accessToken)
+		}
+	} else {
+		// OAuth token
+		r.Header.Del("Authorization")
+		if r.Method != http.MethodOptions {
+			r.Header.Set("Authorization", "Bearer "+accessToken)
+		}
 	}
 
 	log := getLogEntry(r)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -10,6 +10,7 @@ import (
 
 const DefaultGitHubEndpoint = "https://api.github.com"
 const DefaultGitLabEndpoint = "https://gitlab.com/api/v4"
+const DefaultGitLabTokenType = "oauth"
 
 type GitHubConfig struct {
 	AccessToken string `envconfig:"ACCESS_TOKEN" json:"access_token,omitempty"`
@@ -18,9 +19,10 @@ type GitHubConfig struct {
 }
 
 type GitLabConfig struct {
-	AccessToken string `envconfig:"ACCESS_TOKEN" json:"access_token,omitempty"`
-	Endpoint    string `envconfig:"ENDPOINT" json:"endpoint"`
-	Repo        string `envconfig:"REPO" json:"repo"` // Should be "owner/repo" format
+	AccessToken     string `envconfig:"ACCESS_TOKEN" json:"access_token,omitempty"`
+	AccessTokenType string `envconfig:"ACCESS_TOKEN_TYPE" json:"access_token_type"`
+	Endpoint        string `envconfig:"ENDPOINT" json:"endpoint"`
+	Repo            string `envconfig:"REPO" json:"repo"` // Should be "owner/repo" format
 }
 
 // DBConfiguration holds all the database related configuration.
@@ -106,6 +108,11 @@ func LoadConfig(filename string) (*Configuration, error) {
 func (config *Configuration) ApplyDefaults() {
 	if config.GitHub.Endpoint == "" {
 		config.GitHub.Endpoint = DefaultGitHubEndpoint
+	}
+	if config.GitLab.Endpoint == "" {
 		config.GitLab.Endpoint = DefaultGitLabEndpoint
+	}
+	if config.GitLab.AccessTokenType == "" {
+		config.GitLab.AccessTokenType = DefaultGitLabTokenType
 	}
 }


### PR DESCRIPTION
Allows use of _either_ an OAuth _or_ a personal access token by setting the env key `GITGATEWAY_GITLAB_ACCESS_TOKEN_TYPE` to either `"oauth"` or `"personal_access"` (defaulting to `"oauth"`).