### PR TITLE
Git Gateway support for BitBucket

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -77,6 +77,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		}
 		r.With(api.requireAuthentication).Mount("/github", NewGitHubGateway())
 		r.With(api.requireAuthentication).Mount("/gitlab", NewGitLabGateway())
+		r.With(api.requireAuthentication).Mount("/bitbucket", NewBitBucketGateway())
 		r.With(api.requireAuthentication).Get("/settings", api.Settings)
 	})
 

--- a/api/bitbucket.go
+++ b/api/bitbucket.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"regexp"
+	"sync"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/bitbucket"
+)
+
+type BitBucketGateway struct {
+	proxy *httputil.ReverseProxy
+}
+
+func NewBitBucketGateway() *BitBucketGateway {
+	return &BitBucketGateway{
+		proxy: &httputil.ReverseProxy{
+			Director:  bitbucketDirector,
+			Transport: &BitBucketTransport{},
+		},
+	}
+}
+
+var bitbucketPathRegexp = regexp.MustCompile("^/bitbucket/?")
+var bitbucketAllowedRegexp = regexp.MustCompile("^/bitbucket/src/?")
+
+var bitbucketTokenExpirationMessageRegexp = regexp.MustCompile("(?i)^access token expired")
+var currentAccessToken *oauth2.Token
+
+type notifyRefreshTokenSource struct {
+	new oauth2.TokenSource
+	mu  sync.Mutex // guards t
+	t   *oauth2.Token
+}
+
+func (s *notifyRefreshTokenSource) Token() (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.t.Valid() {
+		return s.t, nil
+	}
+	t, err := s.new.Token()
+	if err != nil {
+		return nil, err
+	}
+	s.t = t
+	return t, nil
+}
+
+var currentTokenSource *notifyRefreshTokenSource
+
+func getTokenSource(ctx context.Context) *notifyRefreshTokenSource {
+	config := getConfig(ctx)
+	if currentTokenSource != nil {
+		return currentTokenSource
+	}
+
+	blankToken := &oauth2.Token{
+		AccessToken:  "",
+		RefreshToken: config.BitBucket.RefreshToken,
+	}
+	oauthConfig := &oauth2.Config{
+		ClientID:     config.BitBucket.ClientID,
+		ClientSecret: config.BitBucket.ClientSecret,
+		Endpoint:     bitbucket.Endpoint,
+	}
+	tokenSource := &notifyRefreshTokenSource{
+		new: oauthConfig.TokenSource(ctx, blankToken),
+		t:   blankToken,
+	}
+	currentTokenSource = tokenSource
+	return tokenSource
+}
+
+func bitbucketDirector(r *http.Request) {
+	ctx := r.Context()
+	target := getProxyTarget(ctx)
+	accessToken := getAccessToken(ctx)
+
+	targetQuery := target.RawQuery
+	r.Host = target.Host
+	r.URL.Scheme = target.Scheme
+	r.URL.Host = target.Host
+	r.URL.Path = singleJoiningSlash(target.Path, bitbucketPathRegexp.ReplaceAllString(r.URL.Path, "/"))
+	if targetQuery == "" || r.URL.RawQuery == "" {
+		r.URL.RawQuery = targetQuery + r.URL.RawQuery
+	} else {
+		r.URL.RawQuery = targetQuery + "&" + r.URL.RawQuery
+	}
+	if _, ok := r.Header["User-Agent"]; !ok {
+		r.Header.Set("User-Agent", "")
+	}
+
+	if r.Method != http.MethodOptions {
+		r.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+
+	log := getLogEntry(r)
+	log.Infof("Proxying to BitBucket: %v", r.URL.String(), r.Header.Get("Authorization"))
+}
+
+func (bb *BitBucketGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	config := getConfig(ctx)
+	if config == nil || config.BitBucket.RefreshToken == "" {
+		handleError(notFoundError("No BitBucket Settings Configured"), w, r)
+		return
+	}
+
+	if err := bb.authenticate(w, r); err != nil {
+		handleError(unauthorizedError(err.Error()), w, r)
+		return
+	}
+
+	endpoint := config.BitBucket.Endpoint
+	apiURL := singleJoiningSlash(endpoint, "/repositories/"+config.BitBucket.Repo)
+	target, err := url.Parse(apiURL)
+	if err != nil {
+		handleError(internalServerError("Unable to process BitBucket endpoint"), w, r)
+		return
+	}
+
+	tokenSource := getTokenSource(ctx)
+	token, err := tokenSource.Token()
+	if err != nil {
+		handleError(internalServerError("Unable to process BitBucket endpoint"), w, r)
+	}
+
+	ctx = withProxyTarget(ctx, target)
+	ctx = withAccessToken(ctx, token.AccessToken)
+	bb.proxy.ServeHTTP(w, r.WithContext(ctx))
+}
+
+func (bb *BitBucketGateway) authenticate(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	claims := getClaims(ctx)
+	config := getConfig(ctx)
+
+	if claims == nil {
+		return errors.New("Access to endpoint not allowed: no claims found in Bearer token")
+	}
+
+	if !bitbucketAllowedRegexp.MatchString(r.URL.Path) {
+		return errors.New("Access to endpoint not allowed: this part of BitBucket's API has been restricted")
+	}
+
+	if len(config.Roles) == 0 {
+		return nil
+	}
+
+	roles, ok := claims.AppMetaData["roles"]
+	if ok {
+		roleStrings, _ := roles.([]interface{})
+		for _, data := range roleStrings {
+			role, _ := data.(string)
+			for _, adminRole := range config.Roles {
+				if role == adminRole {
+					return nil
+				}
+			}
+		}
+	}
+
+	return errors.New("Access to endpoint not allowed: your role doesn't allow access")
+}
+
+type BitBucketTransport struct{}
+
+func (t *BitBucketTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := http.DefaultTransport.RoundTrip(r)
+	if err == nil {
+		// remove CORS headers from BitBucket and use our own
+		resp.Header.Del("Access-Control-Allow-Origin")
+	}
+	return resp, err
+}

--- a/api/settings.go
+++ b/api/settings.go
@@ -3,9 +3,10 @@ package api
 import "net/http"
 
 type Settings struct {
-	GitHub bool     `json:"github_enabled"`
-	GitLab bool     `json:"gitlab_enabled"`
-	Roles  []string `json:"roles"`
+	GitHub    bool     `json:"github_enabled"`
+	GitLab    bool     `json:"gitlab_enabled"`
+	BitBucket bool     `json:"bitbucket_enabled"`
+	Roles     []string `json:"roles"`
 }
 
 func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
@@ -13,9 +14,10 @@ func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 	config := getConfig(ctx)
 
 	settings := Settings{
-		GitHub: config.GitHub.Repo != "",
-		GitLab: config.GitLab.Repo != "",
-		Roles:  config.Roles,
+		GitHub:    config.GitHub.Repo != "",
+		GitLab:    config.GitLab.Repo != "",
+		BitBucket: config.BitBucket.Repo != "",
+		Roles:     config.Roles,
 	}
 
 	return sendJSON(w, http.StatusOK, &settings)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -11,6 +11,7 @@ import (
 const DefaultGitHubEndpoint = "https://api.github.com"
 const DefaultGitLabEndpoint = "https://gitlab.com/api/v4"
 const DefaultGitLabTokenType = "oauth"
+const DefaultBitBucketEndpoint = "https://api.bitbucket.org/2.0"
 
 type GitHubConfig struct {
 	AccessToken string `envconfig:"ACCESS_TOKEN" json:"access_token,omitempty"`
@@ -23,6 +24,14 @@ type GitLabConfig struct {
 	AccessTokenType string `envconfig:"ACCESS_TOKEN_TYPE" json:"access_token_type"`
 	Endpoint        string `envconfig:"ENDPOINT" json:"endpoint"`
 	Repo            string `envconfig:"REPO" json:"repo"` // Should be "owner/repo" format
+}
+
+type BitBucketConfig struct {
+	RefreshToken string `envconfig:"REFRESH_TOKEN" json:"refresh_token,omitempty"`
+	ClientID     string `envconfig:"CLIENT_ID" json:"client_id,omitempty"`
+	ClientSecret string `envconfig:"CLIENT_SECRET" json:"client_secret,omitempty"`
+	Endpoint     string `envconfig:"ENDPOINT" json:"endpoint"`
+	Repo         string `envconfig:"REPO" json:"repo"`
 }
 
 // DBConfiguration holds all the database related configuration.
@@ -54,10 +63,11 @@ type GlobalConfiguration struct {
 
 // Configuration holds all the per-instance configuration.
 type Configuration struct {
-	JWT    JWTConfiguration `json:"jwt"`
-	GitHub GitHubConfig     `envconfig:"GITHUB" json:"github"`
-	GitLab GitLabConfig     `envconfig:"GITLAB" json:"gitlab"`
-	Roles  []string         `envconfig:"ROLES" json:"roles"`
+	JWT       JWTConfiguration `json:"jwt"`
+	GitHub    GitHubConfig     `envconfig:"GITHUB" json:"github"`
+	GitLab    GitLabConfig     `envconfig:"GITLAB" json:"gitlab"`
+	BitBucket BitBucketConfig  `envconfig:"BITBUCKET" json:"bitbucket"`
+	Roles     []string         `envconfig:"ROLES" json:"roles"`
 }
 
 func loadEnvironment(filename string) error {
@@ -114,5 +124,8 @@ func (config *Configuration) ApplyDefaults() {
 	}
 	if config.GitLab.AccessTokenType == "" {
 		config.GitLab.AccessTokenType = DefaultGitLabTokenType
+	}
+	if config.BitBucket.Endpoint == "" {
+		config.BitBucket.Endpoint = DefaultBitBucketEndpoint
 	}
 }


### PR DESCRIPTION
**- Summary**

Adds BitBucket support to Git Gateway, including logic to refresh access tokens using a provided refresh token, OAuth client ID, and OAuth client secret.

~This PR needs link rewriting added before it's merged.~ Link rewriting has been added.

**- Test plan**

Tested manually.

**- Description for the changelog**

Git gateway support for BitBucket