### PR TITLE
The existing tag uses a too old version of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ addons:
       - mongodb-org-server
 
 go:
-  - 1.9
-  - 1.10
-  - 1.11
+  - "1.9"
+  - "1.10"
+  - "1.11"
 
 env:
   - git-gateway_MONGODB_TEST_CONN_URL=127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ addons:
       - mongodb-org-server
 
 go:
-  - 1.8
+  - 1.9
+  - 1.10
+  - 1.11
 
 env:
   - git-gateway_MONGODB_TEST_CONN_URL=127.0.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM netlify/go-glide:v0.12.3
+FROM netlify/go-glide
 
 ADD . /go/src/github.com/netlify/git-gateway
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -31,7 +31,7 @@ func (e *OAuthError) WithInternalError(err error) *OAuthError {
 
 // WithInternalMessage adds internal message information to the error
 func (e *OAuthError) WithInternalMessage(fmtString string, args ...interface{}) *OAuthError {
-	e.InternalMessage = fmt.Sprintf(fmtString, args)
+	e.InternalMessage = fmt.Sprintf(fmtString, args...)
 	return e
 }
 
@@ -99,7 +99,7 @@ func (e *HTTPError) WithInternalError(err error) *HTTPError {
 
 // WithInternalMessage adds internal message information to the error
 func (e *HTTPError) WithInternalMessage(fmtString string, args ...interface{}) *HTTPError {
-	e.InternalMessage = fmt.Sprintf(fmtString, args)
+	e.InternalMessage = fmt.Sprintf(fmtString, args...)
 	return e
 }
 


### PR DESCRIPTION
The current tag used of the FROM image, v0.12.3, uses a too old version of Go (1.8). This prevents a successful build of the image:

```
Step 3/5 : RUN useradd -m netlify && cd /go/src/github.com/netlify/git-gateway && make deps build && mv git-gateway /usr/local/bin/
 ---> Running in a9f3d45da33f
# golang.org/x/tools/go/internal/gcimporter
/go/src/golang.org/x/tools/go/internal/gcimporter/bexport.go:212: obj.IsAlias undefined (type *types.TypeName has no field or method IsAlias)
Makefile:13: recipe for target 'deps' failed
make: *** [deps] Error 2
The command '/bin/sh -c useradd -m netlify && cd /go/src/github.com/netlify/git-gateway && make deps build && mv git-gateway /usr/local/bin/' returned a non-zero code: 2
```

There is a new version of the `netlify/go-glide` image pushed, unfortunately it does not have a tag assigned, so we need to rely on the "latest" tag...

**- A picture of a cute animal (not mandatory but encouraged)**

                  ,       ,
                 ( \     / (
                 \  '---'  /
                 /.--. .--,\   .-'''-,
                /\_(o) (o)_/\ /\ | /  \
            __.-.___(_c_)_.-./\ \ / / /)
           (__(((_________)))__--''/ / /
            |  ||  ||  ||  ||  ||   / )
            |  ||  ||  ||  ||  ||   |/
            |  ||  ||  ||  ||  ||   '
            \  ||  ||  ||  ||  ||
             \ ||  ||  ||  |.- -'''- -._
             /\||  ||  ||  ;            :
            |  ||  ||  || :      __      ;
            |  ||  ||  ||:      (  (      :
            |  ||  ||  ||;               .
            |  ||  ||  || ,             , 
            .,_c,__.,__ldb__'- -,..,- -'