### PR TITLE
Allow /statuses/:ref and /commits/:ref/status endpoints for GitHub

### DIFF
--- a/api/github.go
+++ b/api/github.go
@@ -14,7 +14,7 @@ type GitHubGateway struct {
 }
 
 var pathRegexp = regexp.MustCompile("^/github/?")
-var allowedRegexp = regexp.MustCompile("^/github/(git|contents|pulls|branches|merges)/?")
+var allowedRegexp = regexp.MustCompile("^/github/((git|contents|pulls|branches|merges|statuses)/?|(commits/[^/]+/status))")
 
 func NewGitHubGateway() *GitHubGateway {
 	return &GitHubGateway{


### PR DESCRIPTION
**- Summary**

Allows access to commit statuses, which can be used by the CMS to find deploy preview links.

Closes https://github.com/netlify/git-gateway/issues/28.

**- Description for the changelog**

- Allow status endpoints for GitHub