### PR TITLE
Fix quality issues, add DeepSource config

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_path = "github.com/netlify/git-gateway"

--- a/api/bitbucket.go
+++ b/api/bitbucket.go
@@ -213,6 +213,10 @@ func rewriteLinksInBitBucketResponse(resp *http.Response, endpointAPIURL, proxyA
 
 	newBodyBytes, err := json.Marshal(b)
 
+	if err != nil {
+		return err
+	}
+
 	switch resp.Header.Get("Content-Encoding") {
 	case "gzip":
 		var compressedBody bytes.Buffer

--- a/api/gitlab.go
+++ b/api/gitlab.go
@@ -167,7 +167,7 @@ func rewriteGitlabLinkEntry(linkEntry, endpointAPIURL, proxyAPIURL string) strin
 
 func rewriteGitlabLinks(linkHeader, endpointAPIURL, proxyAPIURL string) string {
 	linkEntries := strings.Split(linkHeader, ",")
-	finalLinkEntries := make([]string, len(linkEntries), len(linkEntries))
+	finalLinkEntries := make([]string, len(linkEntries))
 	for i, linkEntry := range linkEntries {
 		finalLinkEntries[i] = rewriteGitlabLinkEntry(linkEntry, endpointAPIURL, proxyAPIURL)
 	}

--- a/models/instance.go
+++ b/models/instance.go
@@ -8,8 +8,6 @@ import (
 	"github.com/netlify/git-gateway/conf"
 )
 
-const baseConfigKey = ""
-
 type Instance struct {
 	ID string `json:"id" bson:"_id,omitempty"`
 	// Netlify UUID


### PR DESCRIPTION
**- Summary**

While the repository runs `go vet` and `go lint` as part of CI, which detects and shows some issues, it doesn't really block the PR for major issues, and the issues are raised for the entire code in the repository. Ideally, the issues should be raised for the changes in a given PR only.

To solve the above problems, this PR introduces DeepSource for code quality analysis.

[DeepSource](https://deepsource.io/) is a free for open-source tool that helps developers and teams write good code. It continuously analyzes code changes on every PR and gives a central dashboard to see code health in terms of issues and important metrics. DeepSource is used by teams at [Uber](https://deepsource.io/gh/uber/ludwig), [NASA](https://deepsource.io/gh/nasa/podaacpy) and [DGraph](https://deepsource.io/gh/dgraph-io/dgraph) among others.

I've added a customized .deepsource.toml file for this repo, and made some fixes for issues existing in the code highlighted by DeepSource. To keep analyzing code on every change, integration is easy:

1. **Merge this PR.**
2. **Sign up on DeepSource** and grant access to this repository [here](https://deepsource.io/signup).
3. **Activate analysis** for this repo [here](https://deepsource.io/gh/Medium/picchu).

You can also take a look at the [docs](https://deepsource.io/docs/). I'll be happy to answer any questions! :)

**- Test plan**

The changes to the code are such that they do not change the functionality in any way. The error handling, the removal of the unused constant and the removal of the redundant parameter (as noted in the changelog) would be caught by the go build tool if there were any new issues.

**- Description for the changelog**

1. Add error handling for json.Marshal, which was previously unhandled.
2. Remove a redundant parameter to `make` for slice, where the capacity parameter is not really required.
3. Remove the `const baseConfigKey = ""`, which is not used anywhere.

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="871" alt="Beebo" src="https://user-images.githubusercontent.com/1070205/70859836-8b60d080-1f3f-11ea-8c1a-2a9a4d12a373.png">

