### PR TITLE
feat: allow GitHub compare API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ for GitHub:
    /repos/:owner/:name/contents/
    /repos/:owner/:name/pulls/
    /repos/:owner/:name/branches/
+   /repos/:owner/:name/merges/
+   /repos/:owner/:name/statuses/
+   /repos/:owner/:name/compare/
 ```
 for GitLab:
 ```

--- a/api/github.go
+++ b/api/github.go
@@ -14,7 +14,7 @@ type GitHubGateway struct {
 }
 
 var pathRegexp = regexp.MustCompile("^/github/?")
-var allowedRegexp = regexp.MustCompile("^/github/((git|contents|pulls|branches|merges|statuses)/?|(commits/[^/]+/status))")
+var allowedRegexp = regexp.MustCompile("^/github/((git|contents|pulls|branches|merges|statuses|compare)/?|(commits/[^/]+/status))")
 
 func NewGitHubGateway() *GitHubGateway {
 	return &GitHubGateway{


### PR DESCRIPTION
Due to a [recent change in Netlify CMS](https://github.com/netlify/netlify-cms/pull/2975/files#diff-18378ab822bf2d64f8822c62d7d915e7R886), we are using the GitHub [compare API](https://developer.github.com/v3/repos/commits/#compare-two-commits) to rebase branches.

Not sure how to go about testing it locally.