### PR TITLE
Upgrade sqlite for macos compat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/joho/godotenv v0.0.0-20161216230537-726cc8b906e3
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/lib/pq v0.0.0-20170810061220-e42267488fe3
-	github.com/mattn/go-sqlite3 v1.1.0
+	github.com/mattn/go-sqlite3 v2.0.2+incompatible
 	github.com/pborman/uuid v0.0.0-20160209185913-a97ce2ca70fa
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/lib/pq v0.0.0-20170810061220-e42267488fe3 h1:2Fs7SMFLrtkGta5HodD3MRV3
 github.com/lib/pq v0.0.0-20170810061220-e42267488fe3/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.1.0 h1:uggQm4+cc4c0du7NMV5XaXTnHRd0Zx9KMCT6csVT6ZI=
 github.com/mattn/go-sqlite3 v1.1.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v2.0.2+incompatible h1:qzw9c2GNT8UFrgWNDhCTqRqYUSmu/Dav/9Z58LGpk7U=
+github.com/mattn/go-sqlite3 v2.0.2+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/pborman/uuid v0.0.0-20160209185913-a97ce2ca70fa h1:l8VQbMdmwFH37kOOaWQ/cw24/u8AuBz5lUym13Wcu0Y=
 github.com/pborman/uuid v0.0.0-20160209185913-a97ce2ca70fa/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
**- Summary**

On macOS the older sqlite lib uses some deprecated libc features. Upgrade to get rid of them in tests.

**- Test plan**

- SQlite is only used in tests

**- Description for the changelog**

Upgrade Sqlite adapter

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://source.unsplash.com/iX_bvOhCLac)