### PR TITLE
feat(github): allow issue/pr labels api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ for GitHub:
    /repos/:owner/:name/merges/
    /repos/:owner/:name/statuses/
    /repos/:owner/:name/compare/
+   /repos/:owner/:name/commits/<sha>/status
+   /repos/:owner/:name/issues/<number>/labels
 ```
 for GitLab:
 ```

--- a/api/github.go
+++ b/api/github.go
@@ -14,7 +14,7 @@ type GitHubGateway struct {
 }
 
 var pathRegexp = regexp.MustCompile("^/github/?")
-var allowedRegexp = regexp.MustCompile("^/github/((git|contents|pulls|branches|merges|statuses|compare)/?|(commits/[^/]+/status))")
+var allowedRegexp = regexp.MustCompile("^/github/((git|contents|pulls|branches|merges|statuses|compare)/?|(commits/[^/]+/status)|(issues/(\\d+)/labels))")
 
 func NewGitHubGateway() *GitHubGateway {
 	return &GitHubGateway{


### PR DESCRIPTION
Related to https://github.com/netlify/netlify-cms/pull/3292 and https://github.com/netlify/netlify-cms/issues/1669

Netlify CMS uses an orphan ref which is hidden from the user to save entry status (e.g. 'draft', 'pending_review', 'pending_publish').

We want to switch to pull requests labels (we've done it already for BitBucket and GitLab).

Tested using a local instance of `git-gateway`, `gotrue` and Netlify CMS