### PR TITLE
fix file/directory target path not in encoded form

### DIFF
--- a/api/gitlab.go
+++ b/api/gitlab.go
@@ -20,7 +20,7 @@ type GitLabGateway struct {
 
 var gitlabPathRegexp = regexp.MustCompile("^/gitlab/?")
 var gitlabAllowedRegexp = regexp.MustCompile("^/gitlab/(merge_requests|(repository/(files|commits|tree|compare|branches)))/?")
-var gitlabEndPathRegexp = regexp.MustCompile("/(raw|rebase|merge|statuses)")
+var gitlabEndPathRegexp = regexp.MustCompile("/(raw|rebase|merge|statuses|refs)")
 
 func NewGitLabGateway() *GitLabGateway {
 	return &GitLabGateway{

--- a/api/gitlab.go
+++ b/api/gitlab.go
@@ -45,19 +45,21 @@ func gitlabDirector(r *http.Request) {
 	// %2F to / in URL paths, and GitLab requires %2F to be preserved
 	// as-is.
 	r.URL.Opaque = "//" + target.Host + singleJoiningSlash(target.EscapedPath(), gitlabPathRegexp.ReplaceAllString(r.URL.EscapedPath(), "/"))
+	// get file path in repository
+	getTargetPath := gitlabAllowedRegexp.ReplaceAllString(r.URL.EscapedPath(), "")
+	// get only /repository/files/
+	gitlabPath := gitlabPathRegexp.ReplaceAllString(r.URL.EscapedPath(), "/")
+	gitlabPath = strings.ReplaceAll(gitlabPath, getTargetPath, "")
 	if strings.Contains(r.URL.Path, "/raw") {
-		// get file path in repository
-		getTargetPath := gitlabAllowedRegexp.ReplaceAllString(r.URL.EscapedPath(), "")
-		// get only /repository/files/
-		gitlabPath := gitlabPathRegexp.ReplaceAllString(r.URL.EscapedPath(), "/")
-		gitlabPath = strings.ReplaceAll(gitlabPath, getTargetPath, "")
 		// first remove /raw, so we can preserve / in %2F form
 		// as GitLab specification to get files, especially inside subfolder
 		// then re-compile gitlabPath and /raw to URL.Opaque .
 		getTargetPath = strings.ReplaceAll(getTargetPath, "/raw", "")
 		getTargetPath = gitlabPath + strings.ReplaceAll(getTargetPath, "/", "%2F") + "/raw"
-		r.URL.Opaque = "//" + target.Host + singleJoiningSlash(target.EscapedPath(), getTargetPath)
+	} else {
+		getTargetPath = gitlabPath + strings.ReplaceAll(getTargetPath, "/", "%2F")
 	}
+	r.URL.Opaque = "//" + target.Host + singleJoiningSlash(target.EscapedPath(), getTargetPath)
 	if targetQuery == "" || r.URL.RawQuery == "" {
 		r.URL.RawQuery = targetQuery + r.URL.RawQuery
 	} else {


### PR DESCRIPTION
Fix #44 .

The idea is based on GitLab API specification that need "%2F" in repository subfolders and repository name.
let say we have these scenario:

1. `GITGATEWAY_GITLAB_REPO=artemtech/play-netlifycms` (in .env file), and
2. We will looking for `content/post/2015-01-04-first-post.md` file

in gitlab.go, these repo will be encoded into `artemtech%2Fplay-netlifycms`. But, the repository contents is not encoded as well (not in %2F form), see:  
`/gitlab.com/api/v4/projects/artemtech%2Fplay-netlifycms/repository/files/content/post/2015-01-04-first-post.md/raw`  

we need to encode `content/post/2015-01-04-first-post.md` part, into `content%2Fpost%2F2015-01-04-first-post.md`.  

so the Opaque URL will become:
`/gitlab.com/api/v4/projects/artemtech%2Fplay-netlifycms/repository/files/content%2Fpost%2F2015-01-04-first-post.md/raw`