### PR TITLE
feat(github): allow commits API for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ for GitHub:
    /repos/:owner/:name/merges/
    /repos/:owner/:name/statuses/
    /repos/:owner/:name/compare/
-   /repos/:owner/:name/commits/<sha>/status
+   /repos/:owner/:name/commits/
    /repos/:owner/:name/issues/<number>/labels
 ```
 for GitLab:

--- a/api/github.go
+++ b/api/github.go
@@ -14,7 +14,7 @@ type GitHubGateway struct {
 }
 
 var pathRegexp = regexp.MustCompile("^/github/?")
-var allowedRegexp = regexp.MustCompile("^/github/((git|contents|pulls|branches|merges|statuses|compare)/?|(commits/[^/]+/status)|(issues/(\\d+)/labels))")
+var allowedRegexp = regexp.MustCompile("^/github/((git|contents|pulls|branches|merges|statuses|compare|commits)/?|(issues/(\\d+)/labels))")
 
 func NewGitHubGateway() *GitHubGateway {
 	return &GitHubGateway{


### PR DESCRIPTION
**- Summary**

As a part of https://github.com/netlify/netlify-cms/pull/3494, the CMS reads a specific file author and date using the commits API:
https://github.com/netlify/netlify-cms/blob/6d9327c3a9c8be9505dd08613d58d01f8ceab45d/packages/netlify-cms-backend-github/src/API.ts#L584

This API was already partially enabled for commit statues and fully enabled for GitLab.

**- Test plan**

Tested on a local instance of `gotrue` and `git-gateway`.

**- Description for the changelog**

Feat(github): allow commits API for GitHub

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/26760571/77918519-ae23b480-72a4-11ea-9083-3fa67b93423e.png)

@mraerino I fixed the animal picture 😄 
