### PR TITLE
fix: set CORS 'Access-Control-Max-Age' header to 86400 seconds

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -126,6 +126,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		AllowedMethods:   []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Private-Token", "Content-Type", audHeaderName},
 		AllowCredentials: true,
+		MaxAge:           86400,
 	})
 
 	api.handler = corsHandler.Handler(chi.ServerBaseContext(r, ctx))


### PR DESCRIPTION
This allows better caching of preflight requests (https://fetch.spec.whatwg.org/#http-access-control-max-age). Not setting it defaults to 5 seconds.
GitHub and Bitbucket use a value of `86400` seconds, while GitLab uses `7200`.
These values correspond with the maximum values for Firefox and Chrome:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age 