### PR TITLE
'git-gateway migrate' command will now actually migrate 

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,29 +5,29 @@
   "repository": "https://github.com/netlify/git-gateway",
   "env": {
     "DATABASE_URL": {},
-    "git-gateway_DB_DRIVER": {
+    "GITGATEWAY_DB_DRIVER": {
       "value": "sqlite3"
     },
-    "git-gateway_DB_AUTOMIGRATE": {
+    "GITGATEWAY_DB_AUTOMIGRATE": {
       "value": true
     },
-    "git-gateway_DB_NAMESPACE": {
+    "GITGATEWAY_DB_NAMESPACE": {
       "value": "auth"
     },
-    "git-gateway_JWT_SECRET": {
+    "GITGATEWAY_JWT_SECRET": {
       "required": true
     },
-    "git-gateway_MAILER_ADMIN_EMAIL": {},
-    "git-gateway_MAILER_HOST": {},
-    "git-gateway_MAILER_MEMBER_FOLDER": {},
-    "git-gateway_MAILER_PASS": {},
-    "git-gateway_MAILER_PORT": {},
-    "git-gateway_MAILER_SITE_URL": {},
-    "git-gateway_MAILER_SUBJECTS_CONFIRMATION": {},
-    "git-gateway_MAILER_SUBJECTS_RECOVERY": {},
-    "git-gateway_MAILER_TEMPLATES_CONFIRMATION": {},
-    "git-gateway_MAILER_TEMPLATES_EMAIL_CHANGE": {},
-    "git-gateway_MAILER_TEMPLATES_RECOVERY": {},
-    "git-gateway_MAILER_USER": {}
+    "GITGATEWAY_MAILER_ADMIN_EMAIL": {},
+    "GITGATEWAY_MAILER_HOST": {},
+    "GITGATEWAY_MAILER_MEMBER_FOLDER": {},
+    "GITGATEWAY_MAILER_PASS": {},
+    "GITGATEWAY_MAILER_PORT": {},
+    "GITGATEWAY_MAILER_SITE_URL": {},
+    "GITGATEWAY_MAILER_SUBJECTS_CONFIRMATION": {},
+    "GITGATEWAY_MAILER_SUBJECTS_RECOVERY": {},
+    "GITGATEWAY_MAILER_TEMPLATES_CONFIRMATION": {},
+    "GITGATEWAY_MAILER_TEMPLATES_EMAIL_CHANGE": {},
+    "GITGATEWAY_MAILER_TEMPLATES_RECOVERY": {},
+    "GITGATEWAY_MAILER_USER": {}
   }
 }

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -9,7 +9,7 @@ import (
 
 var migrateCmd = cobra.Command{
 	Use:  "migrate",
-	Long: "Migrate database strucutures. This will create new tables and add missing columns and indexes.",
+	Long: "Migrate database structures. This will create new tables and add missing columns and indexes.",
 	Run: func(cmd *cobra.Command, args []string) {
 		execWithConfig(cmd, migrate)
 	},
@@ -20,5 +20,14 @@ func migrate(globalConfig *conf.GlobalConfiguration, config *conf.Configuration)
 	if err != nil {
 		logrus.Fatalf("Error opening database: %+v", err)
 	}
+
 	defer db.Close()
+
+	err = db.Automigrate()
+	if err != nil {
+		logrus.Fatalf("Error automigrating database: %+v", err)
+	}
+
+	logrus.Info("Automigration successful")
+
 }

--- a/models/instance.go
+++ b/models/instance.go
@@ -52,7 +52,7 @@ func (i *Instance) BeforeSave() error {
 	return nil
 }
 
-// Config loads the the base configuration values with defaults.
+// Config loads the base configuration values with defaults.
 func (i *Instance) Config() (*conf.Configuration, error) {
 	if i.BaseConfig == nil {
 		return nil, errors.New("no configuration data available")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/git-gateway/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Fixes #25. `migrate` command would do nothing except Dial the sql connection and hang up. It now calls db.Automigrate() explicitly.

Dial does potentially call Automigrate() if you have the right environment variables set, but if you are explicitly attempting to `migrate` then you shouldn't need to set any other variables.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
All tests pass, and the db tables all get created. Tested with sqlite3 and mysql.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
git-gateway migrate command will now function as expected.

**- A picture of a cute animal (not mandatory but encouraged)**
🐮 