### PR TITLE
Fallback to gitlab PAT if token type is not set

### DIFF
--- a/api/gitlab.go
+++ b/api/gitlab.go
@@ -21,6 +21,8 @@ type GitLabGateway struct {
 var gitlabPathRegexp = regexp.MustCompile("^/gitlab/?")
 var gitlabAllowedRegexp = regexp.MustCompile("^/gitlab/(merge_requests|(repository/(files|commits|tree|compare|branches)))/?")
 
+const gitlabPATPrefix = "glpat-"
+
 func NewGitLabGateway() *GitLabGateway {
 	return &GitLabGateway{
 		proxy: &httputil.ReverseProxy{
@@ -61,7 +63,7 @@ func gitlabDirector(r *http.Request) {
 	config := getConfig(ctx)
 	tokenType := config.GitLab.AccessTokenType
 
-	if tokenType == "personal_access" {
+	if tokenType == "personal_access" || (tokenType == "" && strings.HasPrefix(accessToken, gitlabPATPrefix)) {
 		// Private access token
 		r.Header.Del("Authorization")
 		if r.Method != http.MethodOptions {

--- a/api/gitlab.go
+++ b/api/gitlab.go
@@ -21,7 +21,10 @@ type GitLabGateway struct {
 var gitlabPathRegexp = regexp.MustCompile("^/gitlab/?")
 var gitlabAllowedRegexp = regexp.MustCompile("^/gitlab/(merge_requests|(repository/(files|commits|tree|compare|branches)))/?")
 
-const gitlabPATPrefix = "glpat-"
+const (
+	gitlabPATPrefix = "glpat-"
+	tokenTypePAT    = "personal_access"
+)
 
 func NewGitLabGateway() *GitLabGateway {
 	return &GitLabGateway{
@@ -63,7 +66,11 @@ func gitlabDirector(r *http.Request) {
 	config := getConfig(ctx)
 	tokenType := config.GitLab.AccessTokenType
 
-	if tokenType == "personal_access" || (tokenType == "" && strings.HasPrefix(accessToken, gitlabPATPrefix)) {
+	if tokenType == "" && strings.HasPrefix(accessToken, gitlabPATPrefix) {
+		tokenType = tokenTypePAT
+	}
+
+	if tokenType == tokenTypePAT {
 		// Private access token
 		r.Header.Del("Authorization")
 		if r.Method != http.MethodOptions {


### PR DESCRIPTION
**- Summary**

Token type may be empty for gitlab's PAT.

**- Test plan**

- deploy to staging and try to use a gitlab's PAT