### PR TITLE
Don't log access token to info level

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -16,7 +16,7 @@ func (a *API) requireAuthentication(w http.ResponseWriter, r *http.Request) (con
 		return nil, err
 	}
 
-	logrus.Infof("Parsing JWT claims: %v", token)
+	logrus.Debugf("Parsing JWT claims: %v", token)
 	return a.parseJWTClaims(token, r)
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/git-gateway/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Info log level is helpful to have in production as it includes request-level logging however I had to turn it off due to logging the access token to this level. Logging this to debug seems like a much more sensible approach.

**- Test plan**

Just changing the log level.

**- Description for the changelog**

Change log level of access token logs to debug.

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="200" alt="Picture of my english bull terrier" src="https://github.com/netlify/git-gateway/assets/9257001/1e4ae2a2-a5fa-4184-be5a-29569b6dd3f0">

My dog 🥰 
